### PR TITLE
fix variable type of initial value in Leaf

### DIFF
--- a/src/Photosynthesis/types/leaf.jl
+++ b/src/Photosynthesis/types/leaf.jl
@@ -16,7 +16,7 @@ Base.@kwdef mutable struct Leaf{FT<:AbstractFloat}
     "Temperature `[K]`"
     T::FT = 298.15
     "Old Temperature `[K]`, if not T, run leaf_temperature_dependence!"
-    T_old::FT = 0
+    T_old::FT = 0.0
 
     # Photosynthesis system
     "Rate constant for thermal dissipation"
@@ -24,9 +24,9 @@ Base.@kwdef mutable struct Leaf{FT<:AbstractFloat}
     "Rate constant for fluorescence (const)"
     Kf::FT = 0.05
     "Reversible NPQ rate constant (initially zero)"
-    Kr::FT = 0
+    Kr::FT = 0.0
     "Sustained NPQ rate constant (for seasonal changes, default is zero)"
-    Ks::FT = 0
+    Ks::FT = 0.0
     "Rate constant for photochemistry (all reaction centers open)"
     Kp::FT = 4
     "Maximal Kp"
@@ -40,9 +40,9 @@ Base.@kwdef mutable struct Leaf{FT<:AbstractFloat}
 
     # CO₂ pressures
     "Leaf internal CO₂ partial pressure `[Pa]`"
-    p_i::FT = 10
+    p_i::FT = 10.0
     "Leaf surface CO₂ partial pressure `[Pa]`"
-    p_s::FT = 40
+    p_s::FT = 40.0
     "Saturation H₂O vapor pressure `[Pa]`"
     p_sat::FT = saturation_vapor_pressure(T)
     "Leaf diffusive conductance to CO₂ `[mol m⁻² s⁻¹]`"
@@ -52,51 +52,51 @@ Base.@kwdef mutable struct Leaf{FT<:AbstractFloat}
 
     # Photosynthesis related
     "RubisCO limited photosynthetic rate `[μmol m⁻² s⁻¹]`"
-    Ac::FT = 0
+    Ac::FT = 0.0
     "Light limited photosynthetic rate `[μmol m⁻² s⁻¹]`"
-    Aj::FT = 0
+    Aj::FT = 0.0
     "Gross photosynthetic rate `[μmol m⁻² s⁻¹]`"
-    Ag::FT = 0
+    Ag::FT = 0.0
     "Net photosynthetic rate `[μmol m⁻² s⁻¹]`"
-    An::FT = 0
+    An::FT = 0.0
     "Product limited photosynthetic rate `[μmol m⁻² s⁻¹]`"
-    Ap::FT = 0
+    Ap::FT = 0.0
     "Electron transport `[μmol m⁻² s⁻¹]`"
-    J::FT = 0
+    J::FT = 0.0
     "Potential Electron Transport Rate `[μmol m⁻² s⁻¹]`"
-    J_pot::FT = 0
+    J_pot::FT = 0.0
     "Maximal electron transport rate `[μmol m⁻² s⁻¹]`"
-    Jmax::FT = 120
+    Jmax::FT = 120.0
     "Maximal electron transport rate at 298.15 K `[μmol m⁻² s⁻¹]`"
-    Jmax25::FT = 120
+    Jmax25::FT = 120.0
     "RubisCO coefficient Kc `[Pa]`"
-    Kc::FT = 0
+    Kc::FT = 0.0
     "RubisCO coefficient Ko `[Pa]`"
-    Ko::FT = 0
+    Ko::FT = 0.0
     "PEP coefficient Ko `[Pa]`"
-    Kpep::FT = 0
+    Kpep::FT = 0.0
     "Michaelis-Menten's coefficient `[Pa]`"
-    Km::FT = 0
+    Km::FT = 0.0
     "Respiration rate `[μmol m⁻² s⁻¹]`"
     Rd::FT = 1
     "Respiration rate at 298.15 K `[μmol m⁻² s⁻¹]`"
     Rd25::FT = 1
     "Maximal carboxylation rate `[μmol m⁻² s⁻¹]`"
-    Vcmax::FT = 60
+    Vcmax::FT = 60.0
     "Maximal carboxylation rate at 298.15 K `[μmol m⁻² s⁻¹]`"
-    Vcmax25::FT = 60
+    Vcmax25::FT = 60.0
     "Maximal PEP carboxylation rate `[μmol m⁻² s⁻¹]`"
-    Vpmax::FT = 120
+    Vpmax::FT = 120.0
     "Maximal PEP carboxylation rate at 298.15 K `[μmol m⁻² s⁻¹]`"
-    Vpmax25::FT = 120
+    Vpmax25::FT = 120.0
     "CO₂ compensation point with the absence of Rd `[Pa]`"
-    Γ_star::FT = 0
+    Γ_star::FT = 0.0
 
     # Cytochrome related
     "Total concentration of Cytochrome b₆f `[μmol m⁻²]`"
-    C_b₆f::FT = 350 / 300
+    C_b₆f::FT = 350 / 300.0
     "Maximal turnover rate of Cytochrome b₆f `[e⁻ s⁻¹]`"
-    k_q::FT = 300
+    k_q::FT = 300.0
     "Maximal Cytochrome b₆f activity `[μmol e⁻ m⁻² s⁻¹]`"
     Vqmax::FT = C_b₆f * k_q
     "Rate constant of consititutive heat loss from the antennae `[s⁻¹]`"
@@ -110,13 +110,13 @@ Base.@kwdef mutable struct Leaf{FT<:AbstractFloat}
     "Rate constant of photochemistry for PS II `[s⁻¹]`"
     K_P2::FT = 4.5e9
     "Rate constant of excitation sharing for PS II `[s⁻¹]`"
-    K_U2::FT = 0
+    K_U2::FT = 0.0
     "PPFD absorbed by PS I per incident PPFD"
     α_1::FT = 0.41
     "PPFD absorbed by PS II per incident PPFD"
     α_2::FT = 0.44
     "Weighting factor for PS I"
-    ϵ_1::FT = 0
+    ϵ_1::FT = 0.0
     "Weighting factor for PS II"
     ϵ_2::FT = 1
     "Maximal PS I photochemical yield"
@@ -126,25 +126,25 @@ Base.@kwdef mutable struct Leaf{FT<:AbstractFloat}
     "Coupling efficiency of linear electron flow `[mol ATP mol⁻¹ e⁻]`"
     n_L::FT = 0.75
     "ratio between J_P700 and J_P680"
-    η::FT = 0
+    η::FT = 0.0
 
     # related to fluorescence
     "PS II electron transport rate `[μmol e⁻ m⁻² s⁻¹]`"
-    J_P680_a::FT = 0
+    J_P680_a::FT = 0.0
     "Rubisco limited PS II electron transport rate `[μmol e⁻ m⁻² s⁻¹]`"
-    J_P680_c::FT = 0
+    J_P680_c::FT = 0.0
     "Light limited PS II electron transport rate `[μmol e⁻ m⁻² s⁻¹]`"
-    J_P680_j::FT = 0
+    J_P680_j::FT = 0.0
     "Product limited PS II electron transport rate `[μmol e⁻ m⁻² s⁻¹]`"
-    J_P680_p::FT = 0
+    J_P680_p::FT = 0.0
     "PS I electron transport rate `[μmol e⁻ m⁻² s⁻¹]`"
-    J_P700_a::FT = 0
+    J_P700_a::FT = 0.0
     "Rubisco limited PS I electron transport rate `[μmol e⁻ m⁻² s⁻¹]`"
-    J_P700_c::FT = 0
+    J_P700_c::FT = 0.0
     "Light limited PS I electron transport rate `[μmol e⁻ m⁻² s⁻¹]`"
-    J_P700_j::FT = 0
+    J_P700_j::FT = 0.0
     "Product limited PS I electron transport rate `[μmol e⁻ m⁻² s⁻¹]`"
-    J_P700_p::FT = 0
+    J_P700_p::FT = 0.0
 
     # Well watered condition values (to use with β function over PS)
     "Well watered maximal electron transport rate at 298.15 K `[μmol m⁻² s⁻¹]`"
@@ -160,27 +160,27 @@ Base.@kwdef mutable struct Leaf{FT<:AbstractFloat}
     "Total efficiency, incl. photorespiration `[mol CO₂ mol⁻¹ e-]`"
     e2c::FT = 1 / 6
     "dark adapted yield (`Kp=0`)"
-    Fm::FT = 0
+    Fm::FT = 0.0
     "light adapted yield (`Kp=0`)"
-    Fm′::FT = 0
+    Fm′::FT = 0.0
     "dark-adapted fluorescence yield (`Kp=max`)"
-    Fo::FT = 0
+    Fo::FT = 0.0
     "light-adapted fluorescence yield in the dark (`Kp=max`)"
-    Fo′::FT = 0
+    Fo′::FT = 0.0
     "Actual electron transport rate `[μmol m⁻² s⁻¹]`"
-    Ja::FT = 0
+    Ja::FT = 0.0
     "Non-Photochemical quenching "
-    NPQ::FT = 0
+    NPQ::FT = 0.0
     "Photochemical quenching"
-    qQ::FT = 0
+    qQ::FT = 0.0
     "energy quenching"
-    qE::FT = 0
+    qE::FT = 0.0
     "PSII yield"
-    φ::FT = 0
+    φ::FT = 0.0
     "Steady-state (light-adapted) yield (aka Fs)"
-    φs::FT = 0
+    φs::FT = 0.0
 
     # Environment related
     "Absorbed photosynthetic active radiation `[μmol m⁻² s⁻¹]`"
-    APAR::FT = 100
+    APAR::FT = 100.0
 end


### PR DESCRIPTION
王老师好，关注和学习Land.jl很久了，希望能为Land.jl做一点贡献。

## This PR
Julia中`0`是Int64，而非Float。运行`Leaf{Float64}()`会报错。This PR solves this problem.

## 
另外一个疑问：
为何不考虑使用`Parameters.jl`定义struct？这样可以自动收获一个`Base.show` function.
```julia
julia> AirLayer{Float64}()
AirLayer{Float64}
  t_air: Float64 298.15
  p_a: Float64 41.0
  p_atm: Float64 101325.0
  p_H₂O: Float64 1500.0
  p_O₂: Float64 21176.925
  p_sat: Float64 3165.583874755468
  RH: Float64 0.4738462348011141
  vpd: Float64 1665.583874755468
  wind: Float64 2.0
```
原始版本的则为：
```julia
julia> AirLayer{Float64}()
AirLayer{Float64}(298.15, 41.0, 101325.0, 1500.0, 21176.925, 3165.583874755468, 0.4738462348011141, 1665.583874755468, 2.0)
```

如果接受`Parameters.jl`的话，我可以帮忙做一些修改。
